### PR TITLE
Support for ussd numbers with # on android

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -10,6 +10,9 @@ function dial(telNum,prompt) {
 
 		var intent = new android.content.Intent(intentType);
 
+                //support for ussd numbers with # on android
+                telNum = telNum.replace('#', encodeURIComponent('#'));
+
 		intent.setData(android.net.Uri.parse("tel:" + telNum));
 
 		application.android.foregroundActivity.startActivity(intent);


### PR DESCRIPTION
**#** Needs to be url encoded before concatenating with 'tel:' and the rest of the number in android