### PR TITLE
Updated return definition of dial method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,9 @@
  * Initiate a phone call.
  * @param {string} number - The number to dial.
  * @param {boolean} confirm - To enable OS specific confirmation before dialing.
+ * @returns {boolean} Result of dial
  */
-export function dial(number: string, confirm: boolean): void;
+export function dial(number: string, confirm: boolean): boolean;
 
 
 /**


### PR DESCRIPTION
Needed to check result of dial method so displaying a dialog in case device does not allow phone calls so found helpful to rewrite the definition of dial method. 