### PR TITLE
Remove default parameter in dial

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -7,7 +7,7 @@ const ContextCompat = android.support.v4.content.ContextCompat;
 const CALL_PHONE = android.Manifest.permission.CALL_PHONE;
 const PERMISSION_GRANTED = android.content.pm.PackageManager.PERMISSION_GRANTED;
 
-function dial(telNum, prompt = true) {
+function dial(telNum, prompt) {
   try {
     var intentType = Intent.ACTION_DIAL;
 

--- a/index.android.js
+++ b/index.android.js
@@ -9,6 +9,7 @@ const PERMISSION_GRANTED = android.content.pm.PackageManager.PERMISSION_GRANTED;
 
 function dial(telNum, prompt) {
   try {
+    if (prompt === void 0) { prompt = true; }
     var intentType = Intent.ACTION_DIAL;
 
     if (prompt === false) {


### PR DESCRIPTION
To support Webpack including uglifyjs's minification it's necessary to remove the default parameter. Default parameters were first implemented in EC6 and the current version of uglifyjs-webpack-plugin unfortunately supports only EC5.

Right now, you will see the following error when executing `npm run build-android-bundle --uglify`:
```
ERROR in bundle.js from UglifyJs                                                                                                                                                                                                                                                 
Unexpected token operator «=», expected punc «,» [bundle.js:32534,29]
```
