### PR TITLE
Update requestCallPermission method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,11 @@ phone.sms(["212-555-1234","212-555-1245"],"My Message")
 
 #### requestCallPermission: Request Android Call_Phone Permission
 #### Parameters
-* explanationText: The explanation text if the user denies permission twice.
-If you attempt to use `dial("122929912", false)` to not prompt on android 6.0 nothing will happen unless permission has been approved. When this method is executed a check for permissions happens, if no permissions it returns a string as a warning. There is no harm in wrapping your `dial()` inside of the `requestCallPermission()` method.
+* explanation: The explanation text if the user denies permission twice (nullable).
+If you attempt to use `dial("122929912", false)` to not prompt on android 6.0, nothing will happen unless permission has been approved before.
+When this method is executed, a check for permissions happens, and a promise is returned.
+If the user refuse it, you can handle it via the `catch` method of promise. If it accepts you can dial in the `then`method.
+You should so "wrap" your `dial` method inside of the `requestCallPermission()` method (see following example).
 
 
 ### TypeScript example
@@ -116,7 +119,10 @@ import * as TNSPhone from 'nativescript-phone';
 
 /// Dial a phone number.
 public callHome() {
-    TNSPhone.dial('415-123-4567', false);
+   const phoneNumber = '415-123-4567';
+   TNSPhone.requestCallPermission('You should accept the permission to be able to make a direct phone call.')
+      .then(() => TNSPhone.dial(phoneNumber, false))
+      .catch(() => TNSPhone.dial(phoneNumber, true));
 }
 
 // Text a number (or multiple numbers)

--- a/index.android.js
+++ b/index.android.js
@@ -81,21 +81,11 @@ function sms(smsNum, messageText) {
 }
 
 function requestCallPermission(explanation) {
-  if (explanation !== "") {
-    permissions.requestPermission(CALL_PHONE, explanation).then(
-      function(result) {
-        return result;
-      },
-      function(error) {
-        return error;
-      }
-    );
-  }
+    return permissions.requestPermission(CALL_PHONE, explanation);
 }
 
 function hasCallPermission() {
-  var result = permissions.hasPermission(CALL_PHONE);
-  return result;
+  return permissions.hasPermission(CALL_PHONE);
 }
 
 exports.dial = dial;

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,13 @@ export function dial(number: string, confirm: boolean): boolean;
 export function sms(numbers: Array<string>, message: string): Promise<response>;
 
 
+/**
+ * Request Call Permission on Android (dummy function on ios).
+ * @param {string} explanation - The explanation text if the user denies permission twice.
+ * @returns {Promise} Permission granted for then, denied for catch.
+ */
+export function requestCallPermission(explanation?: string): Promise<string>;
+
 interface response {
     "success": string,
     "cancelled": string,

--- a/index.ios.js
+++ b/index.ios.js
@@ -75,5 +75,12 @@ function sms(smsNum, messageText) {
     });
 }
 
+function requestCallPermission(explanation) {
+    return new Promise(function (resolve) {
+        resolve('N/A');
+    });
+}
+
 exports.dial = dial;
 exports.sms = sms;
+exports.requestCallPermission = requestCallPermission;


### PR DESCRIPTION
Hi!

The `requestCallPermission` was not consistent, and not typed so it was not usable without platform check, and not usable with typescript.

Moreover, on android the function didn't return anything so we wasn't able to know if it was succeed before calling phone. It was not a promise, so we was not able to wait the user action before dialing.

This PR fix all of that. It is not a breaking change at all.

Thanks.
Matt'