### PR TITLE
chore: bump permissions version

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "dependencies": {
-    "nativescript-permissions": "1.2.3"
+    "nativescript-permissions": "1.3.6"
   },
   "devDependencies": {
     "prettier": "^1.14.3",


### PR DESCRIPTION
The nativescript-permissions@1.2.3 uses the old Android Support Libraries and will not be compatible with the upcoming NativeScript 6.0 release which will use [AndroidX by default](https://www.nativescript.org/blog/support-for-androidx-in-nativescript). The changes from this PR update this dependency to 1.3.6 which is compatible with the AndroidX library (NS 6.0) and with the old libraries (NS before 6.0).